### PR TITLE
Updating to latest version of MSAL (v2.3.1-preview)

### DIFF
--- a/GroupManager/GroupManager.csproj
+++ b/GroupManager/GroupManager.csproj
@@ -86,8 +86,8 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.Identity.Client, Version=2.0.0.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Identity.Client.2.0.0-preview\lib\net45\Microsoft.Identity.Client.dll</HintPath>
+    <Reference Include="Microsoft.Identity.Client, Version=2.3.1.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Identity.Client.2.3.1-preview\lib\net45\Microsoft.Identity.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel.Protocol.Extensions, Version=1.0.40306.1554, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.Protocol.Extensions.1.0.4.403061554\lib\net45\Microsoft.IdentityModel.Protocol.Extensions.dll</HintPath>

--- a/GroupManager/packages.config
+++ b/GroupManager/packages.config
@@ -18,7 +18,7 @@
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.4" targetFramework="net45" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Identity.Client" version="2.0.0-preview" targetFramework="net45" />
+  <package id="Microsoft.Identity.Client" version="2.3.1-preview" targetFramework="net45" />
   <package id="Microsoft.IdentityModel.Protocol.Extensions" version="1.0.4.403061554" targetFramework="net45" />
   <package id="Microsoft.jQuery.Unobtrusive.Validation" version="3.2.3" targetFramework="net45" />
   <package id="Microsoft.Net.Compilers" version="1.0.0" targetFramework="net45" developmentDependency="true" />

--- a/GroupManager/packages.config
+++ b/GroupManager/packages.config
@@ -18,7 +18,7 @@
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.4" targetFramework="net45" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Identity.Client" version="2.3.1-preview" targetFramework="net45" />
+  <package id="Microsoft.Identity.Client" version="2.3.1-preview" allowedVersions="[2,3)" targetFramework="net45" />
   <package id="Microsoft.IdentityModel.Protocol.Extensions" version="1.0.4.403061554" targetFramework="net45" />
   <package id="Microsoft.jQuery.Unobtrusive.Validation" version="3.2.3" targetFramework="net45" />
   <package id="Microsoft.Net.Compilers" version="1.0.0" targetFramework="net45" developmentDependency="true" />


### PR DESCRIPTION
Upgrading MSAL to 2.3.1

This new version of MSAL was verified by following the instructions in the readme and performing the sign in flow with a standard user account;  then an admin account to grand consent to admin required scopes.