### PR TITLE
Fixed swapped cache methods

### DIFF
--- a/GroupManager/Utils/MSALPerUserSessionTokenCache.cs
+++ b/GroupManager/Utils/MSALPerUserSessionTokenCache.cs
@@ -179,7 +179,11 @@ namespace GroupManager.Utils
         /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
         private void UserTokenCacheAfterAccessNotification(TokenCacheNotificationArgs args)
         {
-            this.LoadUserTokenCacheFromSession();
+			// if the access operation resulted in a cache update
+			if (args.HasStateChanged)
+			{
+				this.PersistUserTokenCache();
+			}
         }
 
         /// <summary>
@@ -188,12 +192,8 @@ namespace GroupManager.Utils
         /// <param name="args">Contains parameters used by the MSAL call accessing the cache.</param>
         private void UserTokenCacheBeforeAccessNotification(TokenCacheNotificationArgs args)
         {
-            // if the access operation resulted in a cache update
-            if (args.HasStateChanged)
-            {
-                this.PersistUserTokenCache();
-            }
-        }
+			this.LoadUserTokenCacheFromSession();
+		}
 
         /// <summary>
         /// Explores the Claims of a signed-in user (if available) to populate the unique Id of this cache's instance.


### PR DESCRIPTION
As an urgent hotfix, I have fixed UserTokenCacheAfterAccessNotification and UserTokenCacheBeforeAccessNotification swapped implementations.

Jean-Marc suggested to improve our .NET 4.X cache providers according to the latest changes on microsoft-authentication-extensions-for-dotnet but since this will require more time, I would like to do this quick hotfix first to prevent developers of cloning a wrong class as soon as possible.
