### PR TITLE
Remove duplicate link in markdown link syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ private async Task<string> GetGraphAccessToken(string[] scopes)
 
 Important things to notice:
 
-- We are requesting an Access Token with the scope `group.read.all`. To get this token we call [AcquireTokenSilent]([https://docs.microsoft.com/en-us/dotnet/api/microsoft.identity.client.clientapplicationbase.acquiretokensilent?view=azure-dotnet](https://docs.microsoft.com/en-us/dotnet/api/microsoft.identity.client.clientapplicationbase.acquiretokensilent?view=azure-dotnet)) method, which attempts to acquire it from the user token cache first avoiding extra call to the Identity Provider.
+- We are requesting an Access Token with the scope `group.read.all`. To get this token we call [AcquireTokenSilent](https://docs.microsoft.com/en-us/dotnet/api/microsoft.identity.client.clientapplicationbase.acquiretokensilent?view=azure-dotnet) method, which attempts to acquire it from the user token cache first avoiding extra call to the Identity Provider.
 - `group.read.all` requires a tenant admin to grant consent. So we redirect the user to the admin consent [endpoint](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-permissions-and-consent#using-the-admin-consent-endpoint) where the tenant admin will be able to grant consent for this scope.
 
 ## How to deploy this sample to Azure


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Remove the duplicate link in markdown link syntax to make correct link work on [published pages](https://review.docs.microsoft.com/en-us/samples/azure-samples/active-directory-dotnet-admin-restricted-scopes-v2/active-directory-dotnet-admin-restricted-scopes-v2/index?branch=master)
* Unblock docfx v3 migration