### PR TITLE
Bump jQuery from 1.10.2 to 3.5.0 in /GroupManager

### DIFF
--- a/GroupManager/packages.config
+++ b/GroupManager/packages.config
@@ -1,9 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.4.1.9004" targetFramework="net472" />
   <package id="bootstrap" version="3.4.1" targetFramework="net472" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net472" />
-  <package id="jQuery" version="1.10.2" targetFramework="net472" />
+  <package id="jQuery" version="3.5.0" targetFramework="net472" />
   <package id="jQuery.Validation" version="1.11.1" targetFramework="net472" />
   <package id="Microsoft.ApplicationInsights" version="1.2.3" targetFramework="net472" />
   <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="1.2.0" targetFramework="net472" />


### PR DESCRIPTION
Bumps jQuery from 1.10.2 to 3.5.0.

---
updated-dependencies:
- dependency-name: jQuery dependency-type: direct:production ...